### PR TITLE
include requirements.txt in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include demo *
 include LICENSE.txt
 include README.md
+include requirements.txt


### PR DESCRIPTION
Without including the `requirements.txt` in the `MANIFEST.in` the installation via pip fails.